### PR TITLE
extract.py called as submodule

### DIFF
--- a/metaMIC/__main__.py
+++ b/metaMIC/__main__.py
@@ -405,7 +405,7 @@ class submodule_args:
         self.contig = options.assemblies
         self.output = options.output
         self.mlen = options.min_length
-        self.pielup = options.pileup
+        self.pileup = options.pileup
         self.samtools = options.samtools
         self.jellyfish = options.jellyfish
         self.thread = options.threads

--- a/metaMIC/__main__.py
+++ b/metaMIC/__main__.py
@@ -27,6 +27,8 @@ import requests
 import shutil
 import tarfile
 import gzip
+# package
+from metaMIC.extract import main as extract_command
 
 base_path = os.path.split(__file__)[0]
 contig_features = [
@@ -397,6 +399,17 @@ def mapping(options):
     return options
 
 
+class submodule_args:
+    def __init__(self, options):
+        self.bam = options.bamfile
+        self.contig = options.assemblies
+        self.output = options.output
+        self.mlen = options.min_length
+        self.pielup = options.pileup
+        self.samtools = options.samtools
+        self.jellyfish = options.jellyfish
+        self.thread = options.threads
+        
 def extract_feature(options):
     """
     Extract four types of features from bamfiles and generate contig-based/window-based feature matrix
@@ -406,17 +419,18 @@ def extract_feature(options):
     if status:
         print("feature files exist and will not re-extract features")
     else:
-        extract_command = ' '.join(['python',
-                                    os.path.join(base_path,"extract.py"),
-                                    '--bam', options.bamfile,
-                                    '--contig', options.assemblies,
-                                    '--output', options.output,
-                                    '--mlen', str(options.min_length),
-                                    '--pileup', options.pileup,
-                                    '--samtools', options.samtools,
-                                    '--jellyfish', options.jellyfish,
-                                    "--thread", str(options.threads)])
-        os.system(extract_command)
+        # extract_command = ' '.join(['python',
+        #                             os.path.join(base_path,"extract.py"),
+        #                             '--bam', options.bamfile,
+        #                             '--contig', options.assemblies,
+        #                             '--output', options.output,
+        #                             '--mlen', str(options.min_length),
+        #                             '--pileup', options.pileup,
+        #                             '--samtools', options.samtools,
+        #                             '--jellyfish', options.jellyfish,
+        #                             "--thread", str(options.threads)])        
+        extract_command(submodule_args(options))
+        # os.system(extract_command)
         # check output features
         check_feature(options)
     # Generate contig-based/window-based matrix

--- a/metaMIC/extract.py
+++ b/metaMIC/extract.py
@@ -629,8 +629,9 @@ def KAD_cal(args):
                                         "temp/KAD/KAD_window_data.txt"), sep="\t")
 
 
-def main():
-    args = parseargs()
+def main(args = None):
+    if args is None:
+        args = parseargs()
     warnings.filterwarnings("ignore")
     os.makedirs(os.path.join(args.output, 'temp', 'read_feature'), exist_ok=True)
     os.makedirs(os.path.join(args.output, 'temp', 'coverage'), exist_ok=True)

--- a/metaMIC/train.py
+++ b/metaMIC/train.py
@@ -47,7 +47,16 @@ def main():
     train_data = pd.read_csv(args.data,sep="\t",index_col=0)
     train_label = pd.read_csv(args.label,sep="\t",header=None,index_col=0)
     train_data['label'] = list(train_label.loc[train_data.index,1])
-    features = ['coverage_width', 'deviation_width', 'normalized_deviation','window_cov_dev', 'fragment_width', 'fragment_deviation_width','normalized_fragment_deviation', 'window_frag_cov_dev','proper_read_ratio', 'clipped_read_ratio', 'supplementary_read_ratio','inversion_read_ratio', 'discordant_loc_ratio', 'discordant_size_ratio','read_breakpoint_ratio', 'proper_read_width', 'clipped_read_width','supplementary_read_width', 'inversion_read_width','discordant_loc_width', 'discordant_size_width', 'read_breakpoint_max','disagree_width', 'correct_portion', 'ambiguous_portion','insert_portion', 'deletion_portion', 'disagree_portion', 'mean_KAD','abnormal_KAD_ratio', 'dev_KAD', 'KAD_width', 'coverage_diff','label']
+    features = ['coverage_width', 'deviation_width', 'normalized_deviation','window_cov_dev',
+                'fragment_width', 'fragment_deviation_width','normalized_fragment_deviation',
+                'window_frag_cov_dev','proper_read_ratio', 'clipped_read_ratio',
+                'supplementary_read_ratio','inversion_read_ratio', 'discordant_loc_ratio',
+                'discordant_size_ratio','read_breakpoint_ratio', 'proper_read_width',
+                'clipped_read_width','supplementary_read_width', 'inversion_read_width',
+                'discordant_loc_width', 'discordant_size_width', 'read_breakpoint_max',
+                'disagree_width', 'correct_portion', 'ambiguous_portion','insert_portion',
+                'deletion_portion', 'disagree_portion', 'mean_KAD','abnormal_KAD_ratio',
+                'dev_KAD', 'KAD_width', 'coverage_diff','label']
     train_data = train_data.loc[:,features]
     training(args,train_data)
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(name='metaMIC',
       description='metaMIC: Reference-free Misassembly Identification and Correction of metagenomic assemblies',
@@ -16,11 +16,11 @@ setup(name='metaMIC',
       url='https://github.com/Seny-l/metaMIC',
       author='Senying Lai',
       license='MIT',
-      packages = ['metaMIC'],
-      package_data={
-          'metaMIC': ['*.py','*.sh']},
-      zip_safe=False,
+      packages = find_packages(exclude=['docs', 'tests', 'examples']),
+      package_data={'metaMIC' : ['*.py','*.sh']},
       entry_points={
-            'console_scripts': ['metaMIC=metaMIC.metaMIC:main'],
-      }
+            'console_scripts' : ['metaMIC=metaMIC.__main__:main'],
+      },
+      zip_safe=False
 )
+


### PR DESCRIPTION
trying to debug the issue with `os.system()` calling extract.py was not working well. Here's an example of calling extract.py directly as a submodule instead of via `os.system()`